### PR TITLE
Add IReadOnly<T> support to most types

### DIFF
--- a/libloc.Access/libloc.Access.csproj
+++ b/libloc.Access/libloc.Access.csproj
@@ -7,10 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DragonFruit.Data" Version="2023.210.0"/>
+        <PackageReference Include="DragonFruit.Data" Version="2023.727.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0"/>
-        <PackageReference Include="SharpCompress" Version="0.33.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+        <PackageReference Include="SharpCompress" Version="0.34.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/libloc.Tests/DatabaseTests.cs
+++ b/libloc.Tests/DatabaseTests.cs
@@ -61,12 +61,12 @@ namespace libloc.Tests
             Assert.IsNull(addressInfo);
         }
 
-        [TestCase(786U)]
-        [TestCase(3333U)]
-        public async Task TestASLookup(uint asn)
+        [TestCase(786)]
+        [TestCase(3333)]
+        public async Task TestASLookup(int asn)
         {
             var database = TestServices.Services.GetRequiredService<ILocationDbAccessor>();
-            var asInfo = await database.PerformAsync(db => db.AS[asn]);
+            var asInfo = await database.PerformAsync(db => db.AS.GetAS(asn));
 
             Assert.IsNotNull(asInfo);
             Assert.IsNotEmpty(asInfo.Name);

--- a/libloc.Tests/libloc.Tests.csproj
+++ b/libloc.Tests/libloc.Tests.csproj
@@ -7,14 +7,20 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DragonFruit.Data.Serializers.SystemJson" Version="2023.210.0" />
+        <PackageReference Include="DragonFruit.Data.Serializers.SystemJson" Version="2023.727.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-        <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-        <PackageReference Include="coverlet.collector" Version="3.2.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.8.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/libloc/Abstractions/IASDatabase.cs
+++ b/libloc/Abstractions/IASDatabase.cs
@@ -5,8 +5,8 @@ using System.Collections.Generic;
 
 namespace libloc.Abstractions
 {
-    public interface IASDatabase : IEnumerable<IDatabaseAS>
+    public interface IASDatabase : IReadOnlyList<IDatabaseAS>
     {
-        IDatabaseAS this[uint index] { get; }
+        IDatabaseAS GetAS(int asn);
     }
 }

--- a/libloc/Abstractions/ICountryDatabase.cs
+++ b/libloc/Abstractions/ICountryDatabase.cs
@@ -5,10 +5,8 @@ using System.Collections.Generic;
 
 namespace libloc.Abstractions
 {
-    public interface ICountryDatabase : IEnumerable<IDatabaseCountry>
+    public interface ICountryDatabase : IReadOnlyList<IDatabaseCountry>
     {
-        IDatabaseCountry this[uint index] { get; }
-
         IDatabaseCountry GetCountry(string code);
     }
 }

--- a/libloc/Abstractions/IDatabaseAS.cs
+++ b/libloc/Abstractions/IDatabaseAS.cs
@@ -5,7 +5,7 @@ namespace libloc.Abstractions
 {
     public interface IDatabaseAS
     {
-        uint Number { get; }
+        int Number { get; }
 
         string Name { get; }
     }

--- a/libloc/Abstractions/INetworkDatabase.cs
+++ b/libloc/Abstractions/INetworkDatabase.cs
@@ -1,10 +1,11 @@
 // liblocsharp - A version of IPFire's libloc library rewritten for C#
 // Licensed under LGPL-2.1 - see the license file for more information
 
+using System.Collections.Generic;
+
 namespace libloc.Abstractions
 {
-    public interface INetworkDatabase
+    public interface INetworkDatabase : IReadOnlyList<IDatabaseNetwork>
     {
-        IDatabaseNetwork this[uint index] { get; }
     }
 }

--- a/libloc/BinaryUtils.cs
+++ b/libloc/BinaryUtils.cs
@@ -20,7 +20,7 @@ namespace libloc
         /// <remarks>
         /// Based on the .NET binary search function (https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Array.cs,b92d187c91d4c9a9)
         /// </remarks>
-        public static T BinarySearch<T, TKey>(int count, Func<uint, T> accessor, TKey target) where T : class, ISearchableItem<TKey>
+        public static T BinarySearch<T, TKey>(int count, Func<int, T> accessor, TKey target) where T : class, ISearchableItem<TKey>
         {
             var lo = 0;
             var hi = count - 1;
@@ -36,7 +36,7 @@ namespace libloc
 
                 try
                 {
-                    item = accessor.Invoke((uint)i);
+                    item = accessor.Invoke(i);
                     c = comparer.Compare(item.Key, target);
                 }
                 catch (Exception e)

--- a/libloc/V1/Collections/DatabaseV1AS.cs
+++ b/libloc/V1/Collections/DatabaseV1AS.cs
@@ -1,6 +1,7 @@
 // liblocsharp - A version of IPFire's libloc library rewritten for C#
 // Licensed under LGPL-2.1 - see the license file for more information
 
+using System;
 using System.Collections.Generic;
 using System.IO.MemoryMappedFiles;
 using System.Linq;
@@ -19,12 +20,25 @@ namespace libloc.V1.Collections
             _pool = pool;
         }
 
-        public IDatabaseAS this[uint asn] => BinaryUtils.BinarySearch(Count, x => FromSource(ElementAt(x)), asn);
+        public IDatabaseAS this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= Count)
+                {
+                    throw new ArgumentOutOfRangeException($"Index must be positive and less than the {nameof(Count)}");
+                }
+
+                return FromSource(ElementAt(index));
+            }
+        }
+
+        public IDatabaseAS GetAS(int asn) => BinaryUtils.BinarySearch(Count, x => FromSource(ElementAt(x)), asn);
 
         private DatabaseAS FromSource(DatabaseSourceAS source)
         {
             var asn = BinaryUtils.EnsureEndianness(source.number);
-            return new DatabaseAS(asn, _pool[source.name_poolid]);
+            return new DatabaseAS((int)asn, _pool[source.name_poolid]);
         }
 
         public IEnumerator<IDatabaseAS> GetEnumerator()

--- a/libloc/V1/Collections/DatabaseV1Collection.cs
+++ b/libloc/V1/Collections/DatabaseV1Collection.cs
@@ -24,7 +24,7 @@ namespace libloc.V1.Collections
 
         public int Count { get; }
 
-        internal protected T ElementAt(uint index)
+        internal protected T ElementAt(int index)
         {
             _view.Read(index * _entitySize, out T data);
             return data;

--- a/libloc/V1/Collections/DatabaseV1Countries.cs
+++ b/libloc/V1/Collections/DatabaseV1Countries.cs
@@ -20,11 +20,11 @@ namespace libloc.V1.Collections
             _pool = pool;
         }
 
-        public DatabaseCountry this[uint index] => FromSource(ElementAt(index));
+        public IDatabaseCountry this[int index] => FromSource(ElementAt(index));
 
         public IDatabaseCountry GetCountry(string code)
         {
-            return BinaryUtils.BinarySearch(Count, x => this[x], code);
+            return BinaryUtils.BinarySearch(Count, x => FromSource(ElementAt(x)), code);
         }
 
         private DatabaseCountry FromSource(DatabaseSourceCountry source)
@@ -39,7 +39,5 @@ namespace libloc.V1.Collections
         {
             return ((IEnumerable<DatabaseSourceCountry>)this).Select(FromSource).GetEnumerator();
         }
-
-        IDatabaseCountry ICountryDatabase.this[uint index] => this[index];
     }
 }

--- a/libloc/V1/Collections/DatabaseV1Networks.cs
+++ b/libloc/V1/Collections/DatabaseV1Networks.cs
@@ -2,6 +2,7 @@
 // Licensed under LGPL-2.1 - see the license file for more information
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO.MemoryMappedFiles;
 using System.Net;
@@ -18,13 +19,13 @@ namespace libloc.V1.Collections
         {
         }
 
-        public IDatabaseNetwork this[uint index] => FromSource(ElementAt(index), null);
+        public IDatabaseNetwork this[int index] => FromSource(ElementAt(index), null);
 
         internal DatabaseNetwork CreateWithPrefix(uint index, Span<byte> v6AddressBytes, int prefix)
         {
             Debug.Assert(v6AddressBytes.Length == 16);
 
-            var networkInfo = ElementAt(index);
+            var networkInfo = ElementAt((int)index);
 
             Span<byte> bitmask = stackalloc byte[v6AddressBytes.Length];
             Span<byte> firstAddressBytes = stackalloc byte[v6AddressBytes.Length];
@@ -50,6 +51,14 @@ namespace libloc.V1.Collections
             var countryCode = Encoding.ASCII.GetString(source.country_code, 2);
 
             return new DatabaseNetwork(network, countryCode, correctedAsn, (NetworkFlags)correctedFlags);
+        }
+
+        public IEnumerator<IDatabaseNetwork> GetEnumerator()
+        {
+            for (var i = 0; i < Count; i++)
+            {
+                yield return this[i];
+            }
         }
     }
 }

--- a/libloc/V1/DatabaseAS.cs
+++ b/libloc/V1/DatabaseAS.cs
@@ -7,9 +7,9 @@ using libloc.Abstractions;
 namespace libloc.V1
 {
     [DebuggerDisplay("AS{Number} - {Name}")]
-    internal record DatabaseAS(uint Number, string Name) : IDatabaseAS, ISearchableItem<uint>
+    internal record DatabaseAS(int Number, string Name) : IDatabaseAS, ISearchableItem<int>
     {
-        uint ISearchableItem<uint>.Key => Number;
+        int ISearchableItem<int>.Key => Number;
 
         public override string ToString() => $"AS{Number}";
     }

--- a/libloc/V1/DatabaseV1.cs
+++ b/libloc/V1/DatabaseV1.cs
@@ -77,7 +77,7 @@ namespace libloc.V1
         public IAddressLocatedNetwork ResolveAddress(IPAddress address)
         {
             var depth = -1;
-            uint nextNodeIndex = 0;
+            int nextNodeIndex = 0;
 
             var mappedAddress = address.MapToIPv6().GetAddressBytes();
             Span<byte> networkAddress = stackalloc byte[mappedAddress.Length];
@@ -97,7 +97,7 @@ namespace libloc.V1
                 AddressUtils.SetAddressBit(networkAddress, depth, bit);
 
                 node = _networkTree.ElementAt(nextNodeIndex);
-                nextNodeIndex = BinaryUtils.EnsureEndianness(bit == 0 ? node.zero : node.one);
+                nextNodeIndex = (int)BinaryUtils.EnsureEndianness(bit == 0 ? node.zero : node.one);
             } while (nextNodeIndex > 0);
 
             if (!node.IsLeaf)

--- a/libloc/V1/DatabaseV1NetworkTreeEnumerator.cs
+++ b/libloc/V1/DatabaseV1NetworkTreeEnumerator.cs
@@ -47,7 +47,7 @@ namespace libloc.V1
                 AddressUtils.SetAddressBit(_networkAddress, node.depth > 0 ? node.depth - 1 : 0, node.nodeOne ? 1 : 0);
 
                 // get node from tree and push next nodes to stack
-                var treeNode = _networkTree.ElementAt(BinaryUtils.EnsureEndianness(node.index));
+                var treeNode = _networkTree.ElementAt((int)BinaryUtils.EnsureEndianness(node.index));
 
                 if (treeNode.one > 0)
                 {

--- a/libloc/libloc.csproj
+++ b/libloc/libloc.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="IPNetwork2" Version="2.6.573"/>
+        <PackageReference Include="IPNetwork2" Version="2.6.611" />
     </ItemGroup>
 
     <Import Project="../Nuget.props"/>


### PR DESCRIPTION
- Exposes the total number of items in a collection
- Changes indexer to always accept the index (not the id of the item to get)